### PR TITLE
fix(actions): Fix GH actions and small error in js

### DIFF
--- a/.github/workflows/github-actions-v1.yaml
+++ b/.github/workflows/github-actions-v1.yaml
@@ -1,7 +1,7 @@
 name: Golang ChatApp CI/CD
 on:
   push:
-    branches: [$default_branch]
+    branches: [main]
   pull_request:
     # types: [labeled]
 jobs:
@@ -12,9 +12,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: '1.23'
+        
+      - run: go version
 
       - name: Install dependencies
         run: go mod download

--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -6,7 +6,7 @@ const formSignUpElement = document.querySelector('.form.signup');
 const buttonSignUpElement = formSignUpElement.querySelector('button');
 // const buttonLoginElement = formLoginElement.querySelector('button');
 
-buttonSignUpElement.addEventListener('click',async (_event) =>{
+buttonSignUpElement.addEventListener('click',async (event) =>{
     event.preventDefault(); // Prevent form from submitting and reloading the page
     
     // Get all inputs and error element

--- a/static/js/room-actions.js
+++ b/static/js/room-actions.js
@@ -1,6 +1,6 @@
 const buttonElement = document.querySelector('button');
 
-buttonElement.addEventListener('click',async (_event) =>{
+buttonElement.addEventListener('click',async (event) =>{
     event.preventDefault(); // Prevent form from submitting and reloading the page
     
     const resp = await fetch('/api/logout');


### PR DESCRIPTION
## Summary of Changes

### `.github/workflows/github-actions-v1.yaml`
- Changed workflow trigger from `[$default_branch]` to `[main]`
- Updated Go setup action from `actions/setup-go@v2` to `actions/setup-go@v5`
- Added a step to print the Go version (`go version`)

### `static/js/actions.js`
- Changed the event handler parameter from `_event` to `event` and used it for `preventDefault()` in the sign-up button click handler

### `static/js/room-actions.js`
- Changed the event handler parameter from `_event` to `event` and used it for `preventDefault()` in the logout button click handler

---

## Explanation

- **Workflow Improvements:**
  - **Branch Trigger:** The GitHub Actions workflow is now set to run only on the `main` branch, making CI/CD triggers more explicit.
  - **Go Setup Update:** Upgraded the Go setup action to the latest major version for improved reliability and features.
  - **Go Version Step:** Added a step to output the Go version, aiding in debugging and transparency in CI logs.

- **JavaScript Event Handling:**
  - Changed the callback parameter from `_event` to `event` for clarity and convention.
  - The event object is now correctly used to call `preventDefault()`, ensuring correct prevention of default browser behavior (such as form submission or page reload).

---

**In summary:**  
These changes improve the CI/CD workflow’s clarity and reliability and make JavaScript event handling more standard and explicit.